### PR TITLE
FIx time conversion into seconds/hundredths

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,11 @@
       "RankingsDB\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "RankingsDB\\Tests\\": "tests/"
+    }
+  },
   "require": {
     "php": ">=5.5",
     "ext-soap": "*"

--- a/src/Time.php
+++ b/src/Time.php
@@ -71,7 +71,7 @@ class Time
      */
     public function getTimeInSeconds()
     {
-        return $this->_seconds * 60 + $this->_seconds + $this->_hundredths / 100;
+        return $this->_minutes * 60 + $this->_seconds + $this->_hundredths / 100;
     }
 
     /**
@@ -85,7 +85,7 @@ class Time
      */
     public function getTimeInHundredths()
     {
-        return 100 * ($this->_seconds * 60 + $this->_seconds) + $this->_hundredths;
+        return 100 * ($this->_minutes * 60 + $this->_seconds) + $this->_hundredths;
     }
 
     public function __toString()

--- a/tests/TimeTest.php
+++ b/tests/TimeTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Author: huw
+ * Since: 2019-10-26
+ */
+
+namespace RankingsDB\Tests;
+
+use PHPUnit\Framework\TestCase;
+use RankingsDB\Event;
+use RankingsDB\Stroke;
+use RankingsDB\Time;
+
+class TimeTest extends TestCase
+{
+
+    public function testGetTimeInSecondsHundredths()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "000012");
+        $this->assertEquals(0.12, $time->getTimeInSeconds());
+    }
+
+    public function testGetTimeInSecondsSeconds()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "001234");
+        $this->assertEquals(12.34, $time->getTimeInSeconds());
+    }
+
+    public function testGetTimeInSecondsMinutes()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "123456");
+        $this->assertEquals(754.56, $time->getTimeInSeconds());
+    }
+
+    public function testGetTimeInHundredthsHundredths()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "000012");
+        $this->assertEquals(12, $time->getTimeInHundredths());
+    }
+
+    public function testGetTimeInHundredthsSeconds()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "001234");
+        $this->assertEquals(1234, $time->getTimeInHundredths());
+    }
+
+    public function testGetTimeInHundredthssMinutes()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "123456");
+        $this->assertEquals(75456, $time->getTimeInHundredths());
+    }
+
+    public function testGetTimeNoLeadingZeroes()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "003456");
+        $this->assertEquals("34.56", $time->getTime(false));
+    }
+
+    public function testGetTimeWithLeadingZeroes()
+    {
+        $event = new Event(Stroke::FREESTYLE, 50);
+        $time = new Time($event, "003456");
+        $this->assertEquals("0:34.56", $time->getTime(true));
+    }
+}


### PR DESCRIPTION
Time::getTimeInSeconds and Time::getTimeInHundredths is broken.
This PR fixes the methods and includes tests to prevent regression.